### PR TITLE
Fix a broken code block display

### DIFF
--- a/docs/snippets/modules/model_io/prompts/prompt_templates/get_started.mdx
+++ b/docs/snippets/modules/model_io/prompts/prompt_templates/get_started.mdx
@@ -106,9 +106,11 @@ llm(template.format_messages(text='i dont like eating tasty things.'))
 ```
 
 <CodeOutputBlock lang="python">
+
 ```
 AIMessage(content='I absolutely adore indulging in delicious treats!', additional_kwargs={}, example=False)
 ```
+
 </CodeOutputBlock>
 
 This provides you with a lot of flexibility in how you construct your chat prompts.


### PR DESCRIPTION
- Description: Fix a broken code block in this page: https://python.langchain.com/docs/modules/model_io/prompts/prompt_templates/
- Issue: N/A
- Dependencies: None
- Tag maintainer: @baskaryan
- Twitter handle: yaotti

## before
<img width="985" alt="image" src="https://github.com/yaotti/langchain/assets/18807/4707fff8-ca64-4144-b1d4-74f641b26f1a">

## after
<img width="987" alt="image" src="https://github.com/yaotti/langchain/assets/18807/d011384f-60a3-416d-99cf-5a29203c5b2b">

